### PR TITLE
fix idb access (scape_main)

### DIFF
--- a/src/io/Database.ts
+++ b/src/io/Database.ts
@@ -35,7 +35,12 @@ export default class Database {
             const request: IDBRequest<Uint8Array> = store.get(name);
 
             request.onsuccess = (): void => {
-                resolve(new Uint8Array(request.result));
+                if (request.result) {
+                    resolve(new Uint8Array(request.result));
+                } else {
+                    // IDB will call onsuccess with "undefined" if key does not exist
+                    resolve(undefined);
+                }
             };
 
             request.onerror = (): void => {


### PR DESCRIPTION
This fixes an issue where a call to the database cache can return a `Unit8Array` of length 0. It is noticed when trying to play the login tune (scape_main.mid). This happens in both of my browsers, Firefox 128 and Chromium 132.

Turns out, the code was not correctly handling the case that an object wasn't in cache. According to the MDN spec, `IDB.get` will behave as if an `undefined` item was stored if the key isn't present.

You can see in the devtools below that the result of `IDB.get(scape_main.mid)` with an empty database calls `onsuccess` with undefined. This causes a zero-length `Uint8Array` which causes the opening theme to not play. The fix is simple.

![image](https://github.com/user-attachments/assets/01082d78-a355-46d6-8bac-df290d4e8545)
