### PR TITLE
fix: don't display 127.0.0.1 on login

### DIFF
--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -1279,7 +1279,10 @@ export class Client extends GameShell {
                 } else {
                     text = this.daysSinceLastLogin + ' days ago';
                 }
-                component.text = 'You last logged in ' + text + ' from: ' + JString.formatIPv4(this.lastAddress); // TODO dns lookup??
+                // Show ip address only if not 127.0.0.1
+                // Production does not record IP so it's always 127.0.0.1
+                const ipStr = JString.formatIPv4(this.lastAddress);
+                component.text = 'You last logged in ' + text + (ipStr === '127.0.0.1' ? '.' : ' from: ' + ipStr);
             }
         } else if (clientCode === Component.CC_UNREAD_MESSAGES) {
             if (this.unreadMessages === 0) {


### PR DESCRIPTION
Current production will show `127.0.0.1` as the IP address all users last logged in from.

This PR removes the reference to the last logged in IP if it matches `127.0.0.1`.

Showing the last logged in IP is authentic, showing `127.0.0.1` is not. I'll leave it to you guys to decide which you prefer!


![last-logged-in](https://github.com/user-attachments/assets/3eb6d137-d9c5-42d5-8500-06b0224aa142)
