### PR TITLE
fix region midi playing after logout

### DIFF
--- a/src/3rdparty/tinymidipcm.js
+++ b/src/3rdparty/tinymidipcm.js
@@ -149,6 +149,7 @@ class TinyMidiPCM {
     const renderInterval = 30;
     const fadeseconds = 2;
 
+    let currentTimeout = null;
     // let renderEndSeconds = 0;
     // let currentMidiBuffer = null;
     let samples = new Float32Array();
@@ -270,6 +271,8 @@ class TinyMidiPCM {
     }
 
     window._tinyMidiStop = async fade => {
+        currentTimeout = null;
+
         if (fade) {
             fadeOut(() => {
                 stop();
@@ -291,8 +294,11 @@ class TinyMidiPCM {
         await window._tinyMidiStop(fade);
 
         if (fade) {
-            setTimeout(() => {
-                start(vol, midiBuffer);
+            currentTimeout = setTimeout(() => {
+                if (currentTimeout) {
+                    start(vol, midiBuffer);
+                }
+                currentTimeout = null;
             }, fadeseconds * 1000);
         } else {
             start(vol, midiBuffer);

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -2352,7 +2352,6 @@ export class Client extends GameShell {
                 for (let i: number = 0; i < 5; i++) {
                     this.designColors[i] = 0;
                 }
-                stopMidi(true); // custom fix :-)
                 Client.oplogic1 = 0;
                 Client.oplogic2 = 0;
                 Client.oplogic3 = 0;


### PR DESCRIPTION
This change stops midi from playing when timeout ends if tinyMidiStop got called without fade (for logout)
fixes https://github.com/2004Scape/Server/issues/1221

I also removed Jordans custom fix, but not sure what originally caused it. It was used when setMidi scape_main was still being set on logout though. This one might have to be re-added...

Also this midi fade code probably needs some clean up in general at some point, but it should work for now hopefully