### PR TITLE
authentic midi

### DIFF
--- a/src/3rdparty/tinymidipcm.js
+++ b/src/3rdparty/tinymidipcm.js
@@ -149,7 +149,8 @@ class TinyMidiPCM {
     const renderInterval = 30;
     const fadeseconds = 2;
 
-    let currentTimeout = null;
+    let midiTimeout = null;
+    let fadeTimeout = null;
     // let renderEndSeconds = 0;
     // let currentMidiBuffer = null;
     let samples = new Float32Array();
@@ -235,7 +236,7 @@ class TinyMidiPCM {
         const currentTime = window.audioContext.currentTime;
         gainNode.gain.cancelScheduledValues(currentTime);
         gainNode.gain.setTargetAtTime(0, currentTime, 0.5);
-        setTimeout(callback, fadeseconds * 1000);
+        return setTimeout(callback, fadeseconds * 1000);
     }
 
     function stop() {
@@ -272,12 +273,15 @@ class TinyMidiPCM {
 
     window._tinyMidiStop = async fade => {
         if (fade) {
-            fadeOut(() => {
-                stop();
+            fadeTimeout = fadeOut(() => {
+                if (fadeTimeout) {
+                    stop();
+                }
             });
         } else {
             stop();
-            currentTimeout = null;
+            midiTimeout = null;
+            fadeTimeout = null
         }
     };
 
@@ -293,8 +297,8 @@ class TinyMidiPCM {
         await window._tinyMidiStop(fade);
 
         if (fade) {
-            currentTimeout = setTimeout(() => {
-                if (currentTimeout) {
+            midiTimeout = setTimeout(() => {
+                if (midiTimeout) {
                     start(vol, midiBuffer);
                 }
             }, fadeseconds * 1000);

--- a/src/3rdparty/tinymidipcm.js
+++ b/src/3rdparty/tinymidipcm.js
@@ -271,14 +271,13 @@ class TinyMidiPCM {
     }
 
     window._tinyMidiStop = async fade => {
-        currentTimeout = null;
-
         if (fade) {
             fadeOut(() => {
                 stop();
             });
         } else {
             stop();
+            currentTimeout = null;
         }
     };
 
@@ -298,7 +297,6 @@ class TinyMidiPCM {
                 if (currentTimeout) {
                     start(vol, midiBuffer);
                 }
-                currentTimeout = null;
             }, fadeseconds * 1000);
         } else {
             start(vol, midiBuffer);


### PR DESCRIPTION
Last change would break if multiple midi songs are fading (by walking between music regions) as we clear the newest timeout, and was unneeded.
1. Directly fixing the original issue at hand this time, only avoid starting next midi if calling stop without fade.

Another issue that wasn't noticed before as it was incorrectly playing midi regardless in this case:
2. if you click "off" in the midi player instantly as a new midi track fades in, then set it to any volume again before it's finished fading, it will only play for a split second and then stop.

Tried breaking it this time and all seems to work correctly.