### PR TITLE
fix(engine): correct left click input tracking

### DIFF
--- a/src/client/InputTracking.ts
+++ b/src/client/InputTracking.ts
@@ -76,7 +76,7 @@ export default class InputTracking {
         }
         this.lastTime = now;
         this.ensureCapacity(2);
-        if (button === 1) {
+        if (button === 1 || button === 0) {
             this.outBuffer?.p1(3);
         } else {
             this.outBuffer?.p1(4);

--- a/src/client/InputTracking.ts
+++ b/src/client/InputTracking.ts
@@ -52,10 +52,7 @@ export default class InputTracking {
         }
         this.lastTime = now;
         this.ensureCapacity(5);
-	// 0 = left
-	// 1 = middle
-	// 2 = right
-        if (button === 1 || button === 0) {
+        if (button === 2) {
             this.outBuffer?.p1(1);
         } else {
             this.outBuffer?.p1(2);
@@ -76,7 +73,7 @@ export default class InputTracking {
         }
         this.lastTime = now;
         this.ensureCapacity(2);
-        if (button === 1 || button === 0) {
+        if (button === 2) {
             this.outBuffer?.p1(3);
         } else {
             this.outBuffer?.p1(4);

--- a/src/client/InputTracking.ts
+++ b/src/client/InputTracking.ts
@@ -52,7 +52,10 @@ export default class InputTracking {
         }
         this.lastTime = now;
         this.ensureCapacity(5);
-        if (button === 1) {
+	// 0 = left
+	// 1 = middle
+	// 2 = right
+        if (button === 1 || button === 0) {
             this.outBuffer?.p1(1);
         } else {
             this.outBuffer?.p1(2);


### PR DESCRIPTION
Left click has `e.button === 0`, which was getting recorded as a right-click.