### PR TITLE
fix(engine): fix right-mouse state on mobile

### DIFF
--- a/src/client/GameShell.ts
+++ b/src/client/GameShell.ts
@@ -632,7 +632,9 @@ export default abstract class GameShell {
 
         if (longPress && !moved) {
             this.touching = true;
+            // Send both down and up events to simulate a right-click.
             this.onmousedown(new MouseEvent('mousedown', { clientX, clientY, button: 2 }));
+            this.onmouseup(new MouseEvent('mouseup', { clientX, clientY, button: 2 }));
         }
     };
 


### PR DESCRIPTION
Currently we send only a `mousedown` event when we detect a mobile long-press. We should be sending also a `mouseup` otherwise the client's internal state gets messed up.