### PR TITLE
fix(engine): remove redundant overflow check in ClientStream read

### DIFF
--- a/src/io/ClientStream.ts
+++ b/src/io/ClientStream.ts
@@ -178,11 +178,6 @@ class WebSocketReader {
         } else {
             this.queue.push(event);
         }
-
-        // check for the overflow after the callback
-        if (this.available > this.limit) {
-            throw new Error('Buffer overflow');
-        }
     };
 
     async read(): Promise<number> {


### PR DESCRIPTION
Looking at the browser logs while playing, I saw there are often hundreds of error messages when the client requests RebuildGetMaps.

![ws_error](https://github.com/user-attachments/assets/1958351a-67b6-4670-ab6a-965fc3ef715b)


Looking at the source, we perform a check for whether more than 5000 bytes are received in one Websocket message event. This seemed odd, since the server doesn't deliberately fragment messages to be within this range.

I then took a look at Client2, the repo that predates Client-TS, and saw it was added by
https://github.com/2004Scape/Client2/commit/413683d5cf3cbeb805bfef606f153953727203c4. Checking [the Java 1:1 source](https://github.com/2004Scape/Client/blob/lastmain/runetek3/src/main/java/jagex2/io/ClientStream.java#L95), the overflow check (5000 bytes) was done only on ClientStream send, not recv. That commit added the overflow check to both send and recv.

This PR removes the overflow check on recv since it doesn't really do anything (the errors don't impact the game) except flood the browser logs, and wasn't present in the Java source.

Looks to still work properly through some quick testing.