### PR TITLE
feat: component alpha support & expand layer max children count

### DIFF
--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -924,10 +924,17 @@ export class Client extends GameShell {
                     }
                 }
             } else if (child.comType === ComponentType.TYPE_RECT) {
-                if (child.fill) {
-                    Pix2D.fillRect2d(childX, childY, child.width, child.height, child.colour);
+                if (child.alpha === 0) {
+                    if (child.fill) {
+                        Pix2D.fillRect2d(childX, childY, child.width, child.height, child.colour);
+                    } else {
+                        Pix2D.drawRect(childX, childY, child.width, child.height, child.colour);
+                    }
+                } else if (child.fill) {
+                    Pix2D.fillRectAlpha(childX, childY, child.width, child.height, child.colour, 256 - (child.alpha & 0xFF));
                 } else {
                     Pix2D.drawRect(childX, childY, child.width, child.height, child.colour);
+                    Pix2D.drawRectAlpha(childX, childY, child.width, child.height, child.colour, 256 - (child.alpha & 0xFF));
                 }
             } else if (child.comType === ComponentType.TYPE_TEXT) {
                 const font: PixFont | null = child.font;

--- a/src/config/Component.ts
+++ b/src/config/Component.ts
@@ -61,6 +61,7 @@ export default class Component {
             com.clientCode = dat.g2();
             com.width = dat.g2();
             com.height = dat.g2();
+            com.alpha = dat.g1();
 
             com.overLayer = dat.g1();
             if (com.overLayer === 0) {
@@ -99,7 +100,7 @@ export default class Component {
                 com.scroll = dat.g2();
                 com.hide = dat.g1() === 1;
 
-                const childCount: number = dat.g1();
+                const childCount: number = dat.g2();
                 com.childId = new Array(childCount);
                 com.childX = new Array(childCount);
                 com.childY = new Array(childCount);
@@ -379,6 +380,7 @@ export default class Component {
     clientCode: number = 0;
     width: number = 0;
     height: number = 0;
+    alpha: number = 0;
     overLayer: number = -1;
     scriptComparator: Uint8Array | null = null;
     scriptOperand: Uint16Array | null = null;

--- a/src/graphics/Pix2D.ts
+++ b/src/graphics/Pix2D.ts
@@ -71,6 +71,15 @@ export default class Pix2D extends DoublyLinkable {
         this.drawVerticalLine(x + w - 1, y, color, h);
     }
 
+    static drawRectAlpha(x: number, y: number, w: number, h: number, color: number, alpha: number): void {
+        this.drawHorizontalLineAlpha(x, y, color, w, alpha);
+        this.drawHorizontalLineAlpha(x, y + h - 1, color, w, alpha);
+        if (h >= 3) {
+            this.drawVerticalLineAlpha(x, y, color, h, alpha);
+            this.drawVerticalLineAlpha(x + w - 1, y, color, h, alpha);
+        }
+    }
+
     static drawHorizontalLine(x: number, y: number, color: number, width: number): void {
         if (y < this.top || y >= this.bottom) {
             return;
@@ -91,25 +100,83 @@ export default class Pix2D extends DoublyLinkable {
         }
     }
 
-    static drawVerticalLine(x: number, y: number, color: number, width: number): void {
+    static drawHorizontalLineAlpha = (x: number, y: number, color: number, width: number, alpha: number): void => {
+        if (y < this.top || y >= this.bottom) {
+            return;
+        }
+
+        if (x < this.left) {
+            width -= this.left - x;
+            x = this.left;
+        }
+
+        if (x + width > this.right) {
+            width = this.right - x;
+        }
+
+        const invAlpha: number = 256 - alpha;
+        const r0: number = ((color >> 16) & 0xff) * alpha;
+        const g0: number = ((color >> 8) & 0xff) * alpha;
+        const b0: number = (color & 0xff) * alpha;
+        const step: number = this.width2d - width;
+        let offset: number = x + y * this.width2d;
+        for (let i: number = 0; i < width; i++) {
+            const r1: number = ((this.pixels[offset] >> 16) & 0xff) * invAlpha;
+            const g1: number = ((this.pixels[offset] >> 8) & 0xff) * invAlpha;
+            const b1: number = (this.pixels[offset] & 0xff) * invAlpha;
+            const color: number = (((r0 + r1) >> 8) << 16) + (((g0 + g1) >> 8) << 8) + ((b0 + b1) >> 8);
+            this.pixels[offset++] = color;
+        }
+    };
+
+    static drawVerticalLine(x: number, y: number, color: number, height: number): void {
         if (x < this.left || x >= this.right) {
             return;
         }
 
         if (y < this.top) {
-            width -= this.top - y;
+            height -= this.top - y;
             y = this.top;
         }
 
-        if (y + width > this.bottom) {
-            width = this.bottom - y;
+        if (y + height > this.bottom) {
+            height = this.bottom - y;
         }
 
         const off: number = x + y * this.width2d;
-        for (let i: number = 0; i < width; i++) {
+        for (let i: number = 0; i < height; i++) {
             this.pixels[off + i * this.width2d] = color;
         }
     }
+
+    static drawVerticalLineAlpha = (x: number, y: number, color: number, height: number, alpha: number): void => {
+        if (x < this.left || x >= this.right) {
+            return;
+        }
+
+        if (y < this.top) {
+            height -= this.top - y;
+            y = this.top;
+        }
+
+        if (y + height > this.bottom) {
+            height = this.bottom - y;
+        }
+
+        const invAlpha: number = 256 - alpha;
+        const r0: number = ((color >> 16) & 0xff) * alpha;
+        const g0: number = ((color >> 8) & 0xff) * alpha;
+        const b0: number = (color & 0xff) * alpha;
+        let offset: number = x + y * this.width2d;
+        for (let i: number = 0; i < height; i++) {
+            const r1: number = ((this.pixels[offset] >> 16) & 0xff) * invAlpha;
+            const g1: number = ((this.pixels[offset] >> 8) & 0xff) * invAlpha;
+            const b1: number = (this.pixels[offset] & 0xff) * invAlpha;
+            const color: number = (((r0 + r1) >> 8) << 16) + (((g0 + g1) >> 8) << 8) + ((b0 + b1) >> 8);
+            this.pixels[offset] = color;
+            offset += this.width2d;
+        }
+    };
 
     static drawLine(x1: number, y1: number, x2: number, y2: number, color: number): void {
         const dx: number = Math.abs(x2 - x1);


### PR DESCRIPTION
Add support for Component `alpha` property, also adds support for drawing transparent rectangles.

![image](https://github.com/user-attachments/assets/dd9a5899-25b4-4fda-94a3-686776a3058a)
