### PR TITLE
fix(input): fix missing keyboard events

### DIFF
--- a/src/client/GameShell.ts
+++ b/src/client/GameShell.ts
@@ -209,8 +209,6 @@ export default abstract class GameShell {
                 this.lastMouseClickButton = 0;
 
                 await this.update();
-
-                this.keyQueueReadPos = this.keyQueueWritePos;
                 count += ratio;
             }
             count &= 0xff;


### PR DESCRIPTION
On the title screen specifically, there was an annoying situation where keyboard events would get swallowed and not do anything. This was due to the `keyQueueReadPos` being incremented not only in `pollKey`, but also in `GameShell.run()`.

I'm not sure why the key queue read index gets increased in the main 'run' loop as well as in pollKey, but by removing it from the main loop, keyboard inputs are no longer disappearing when OnDemand is churning away on the title login screen. It could be due to browser lag messing with the async timings.

Express caution merging this as I don't really know why the code was this way in the first place.