### PR TITLE
fix: incorrectly assigned seqtype property

### DIFF
--- a/src/config/SeqType.ts
+++ b/src/config/SeqType.ts
@@ -64,7 +64,7 @@ export default class SeqType extends ConfigType {
 
             if (seq.postanim_move === -1) {
                 if (seq.walkmerge === null) {
-                    seq.preanim_move = PostanimMove.DELAYMOVE;
+                    seq.postanim_move = PostanimMove.DELAYMOVE;
                 } else {
                     seq.postanim_move = PostanimMove.MERGE;
                 }


### PR DESCRIPTION
Fixes this behavior

## Before

https://github.com/user-attachments/assets/4995c55a-0389-4b15-a56d-c8a4c609c6f9

## After
![chrome_5HdmVGPAaJ](https://github.com/user-attachments/assets/e2d44e66-71dd-4d89-b44c-6b41ed951a34)
