### PR TITLE
fix: correct shadow inside noted items in inventory

### DIFF
--- a/src/config/ObjType.ts
+++ b/src/config/ObjType.ts
@@ -481,7 +481,7 @@ export default class ObjType extends ConfigType {
                     }
                 }
             }
-        } else {
+        } else if (outlineRgb === 0) {
             // draw shadow
             for (let x: number = 31; x >= 0; x--) {
                 for (let y: number = 31; y >= 0; y--) {


### PR DESCRIPTION
using ObjType.java as reference, there was a mistake in checking for outlineRgb. In the case of drawing an item inside a certificate template, it has value -1, which was mistakenly triggering the shadow drawing code.

## JS (incorrect)
<img width="286" height="266" alt="js" src="https://github.com/user-attachments/assets/a20cbe9f-6029-4a62-8070-e6ba24df778a" />

## Java (correct)
<img width="285" height="261" alt="java" src="https://github.com/user-attachments/assets/71df6b92-3344-492a-8fa5-a462f5af80f9" />
