### PR TITLE
fix: allow display of blank public chat messages

### DIFF
--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -10628,7 +10628,7 @@ export class Client extends GameShell {
 
             for (let i: number = 0; i < 100; i++) {
                 const message: string | null = this.messageText[i];
-                if (!message) {
+                if (message === null) {
                     continue;
                 }
 


### PR DESCRIPTION
Referencing the Java client, chat should allow people to type blank public chat messages to eachother by entering a \<space> only. TS port was aborting early if a blank message was encountered.

<img width="146" height="71" alt="image" src="https://github.com/user-attachments/assets/d064892f-1285-494f-8de4-f5556cede632" />
