### PR TITLE
fix: missing check for mod chats override

### DIFF
--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -10821,7 +10821,7 @@ export class Client extends GameShell {
                     }
 
                     line++;
-                } else if ((type === 1 || type === 2) && (this.chatPublicMode === 0 || (this.chatPublicMode === 1 && this.isFriend(sender)))) {
+                } else if ((type === 1 || type === 2) && (type === 1 || this.chatPublicMode === 0 || (this.chatPublicMode === 1 && this.isFriend(sender)))) {
                     if (y > 0 && y < 110) {
                         let x = 4;
                         if (modlevel == 1) {


### PR DESCRIPTION
Seen in Java client here: https://github.com/LostCityRS/Client-Java/blob/176a85f7b423111c878a476e1ead048745e377c0/src/main/java/jagex2/client/Client.java#L11190

Fixes bug with accepting trade requests when public chat is set to hidden, but mods have talked recently:
https://www.youtube.com/watch?v=HEwWph8Vj4I&t=27013s