### PR TITLE
Fix: always resume p_countdialog on empty input (make x)

### DIFF
--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -3031,17 +3031,14 @@ export class Client extends GameShell {
                         }
 
                         if (key === 13 || key === 10) {
+                            let value: number = 0;
                             if (this.dialogInput.length > 0) {
-                                let value: number = 0;
-                                try {
-                                    value = parseInt(this.dialogInput, 10);
-                                } catch (_e) {
-                                    // empty
-                                }
-
-                                this.out.p1Enc(ClientProt.RESUME_P_COUNTDIALOG);
-                                this.out.p4(value);
+                                const parsed: number = parseInt(this.dialogInput, 10);
+                                value = Number.isNaN(parsed) ? 0 : parsed;
                             }
+
+                            this.out.p1Enc(ClientProt.RESUME_P_COUNTDIALOG);
+                            this.out.p4(value);
 
                             this.dialogInputOpen = false;
                             this.redrawChat = true;


### PR DESCRIPTION
Empty enter on a count dialog sent no packet back, so p_countdialog never resumed and hung the player. Client side - content callers already guard last_int <= 0. Now always resumes, empty = 0. Surfaced in Make X since its dialog sits under a menu meant to stay open, so it showed as a dead menu you had to click out of, vs other callers (bank, trade, tanner) just closing quietly.

To return to make menu vs close completely -- will be PR on chat.rs if authentic behavior.

seen in game issues:  https://discord.com/channels/953326730632904844/1520423975283458139


pre:

https://github.com/user-attachments/assets/39e7dae9-a321-4b33-85d3-27c2ea3c1a4d


with client.ts PR alone -- blank is treated like 0


https://github.com/user-attachments/assets/84e45376-ef18-45af-b9d5-38f7dd3ceb00



with client.ts PR + chat.rs2 PR **(ONLY IF AUTHENTIC -- I believe this not to be - so it won't be submitted at the moment)**


https://github.com/user-attachments/assets/1d9dd609-95c5-45f2-a343-e5fb14f30757

